### PR TITLE
Support for teracopy.

### DIFF
--- a/Explorer++/Helper/DropHandler.h
+++ b/Explorer++/Helper/DropHandler.h
@@ -5,6 +5,10 @@
 #include "FileOperations.h"
 #include "ReferenceCount.h"
 
+/* now using in drop handler for shell extension file copy */
+HRESULT	CreateDataObject(FORMATETC *,STGMEDIUM *,IDataObject **,int);
+
+
 enum DragTypes_t
 {
 	DRAG_TYPE_LEFTCLICK,

--- a/Explorer++/Helper/ShellHelper.h
+++ b/Explorer++/Helper/ShellHelper.h
@@ -112,6 +112,7 @@ BOOL			CompareIdls(LPCITEMIDLIST pidl1,LPCITEMIDLIST pidl2);
 HRESULT			AddJumpListTasks(const std::list<JumpListTaskInformation> &TaskList);
 BOOL			LoadContextMenuHandlers(const TCHAR *szRegKey, std::list<ContextMenuHandler_t> &ContextMenuHandlers);
 BOOL			LoadIUnknownFromCLSID(const TCHAR *szCLSID, ContextMenuHandler_t *pContextMenuHandler);
+BOOL			LoadShellExtensionHandlers(bool bCopy, LPCITEMIDLIST pidlDirectory, IDataObject *pDataObject);
 HRESULT			GetItemAttributes(const TCHAR *szItemParsingPath, SFGAOF *pItemAttributes);
 HRESULT			GetItemAttributes(LPCITEMIDLIST pidl, SFGAOF *pItemAttributes);
 BOOL			ExecuteFileAction(HWND hwnd, const TCHAR *szVerb, const TCHAR *szParameters, const TCHAR *szStartDirectory, LPCITEMIDLIST pidl);


### PR DESCRIPTION
Support for teracopy shell extension on file copy/move to override internal file copy.

The scroll lock key override to disable/enable teracopy does not work.

Signed-off-by: dbosst@gmail.com dbosst@gmail.com

Note: Lightly tested OK on Windows XP (checked copy/move across drives & network shares).  Don't have a clue yet how to get the scroll-lock disable feature of teracopy working.
