### PR TITLE
Fix bookmarks sort issue

### DIFF
--- a/Explorer++/Explorer++/BookmarkHelper.cpp
+++ b/Explorer++/Explorer++/BookmarkHelper.cpp
@@ -532,7 +532,7 @@ int CALLBACK SortByName(const NBookmarkHelper::variantBookmark_t BookmarkItem1,
 	else
 	{
 		const CBookmark &Bookmark1 = boost::get<CBookmark>(BookmarkItem1);
-		const CBookmark &Bookmark2 = boost::get<CBookmark>(BookmarkItem1);
+		const CBookmark &Bookmark2 = boost::get<CBookmark>(BookmarkItem2);
 
 		return Bookmark1.GetName().compare(Bookmark2.GetName());
 	}
@@ -549,7 +549,7 @@ int CALLBACK SortByLocation(const NBookmarkHelper::variantBookmark_t BookmarkIte
 	else
 	{
 		const CBookmark &Bookmark1 = boost::get<CBookmark>(BookmarkItem1);
-		const CBookmark &Bookmark2 = boost::get<CBookmark>(BookmarkItem1);
+		const CBookmark &Bookmark2 = boost::get<CBookmark>(BookmarkItem2);
 
 		return Bookmark1.GetLocation().compare(Bookmark2.GetLocation());
 	}
@@ -566,7 +566,7 @@ int CALLBACK SortByVisitDate(const NBookmarkHelper::variantBookmark_t BookmarkIt
 	else
 	{
 		const CBookmark &Bookmark1 = boost::get<CBookmark>(BookmarkItem1);
-		const CBookmark &Bookmark2 = boost::get<CBookmark>(BookmarkItem1);
+		const CBookmark &Bookmark2 = boost::get<CBookmark>(BookmarkItem2);
 
 		FILETIME ft1 = Bookmark1.GetDateLastVisited();
 		FILETIME ft2 = Bookmark2.GetDateLastVisited();
@@ -586,7 +586,7 @@ int CALLBACK SortByVisitCount(const NBookmarkHelper::variantBookmark_t BookmarkI
 	else
 	{
 		const CBookmark &Bookmark1 = boost::get<CBookmark>(BookmarkItem1);
-		const CBookmark &Bookmark2 = boost::get<CBookmark>(BookmarkItem1);
+		const CBookmark &Bookmark2 = boost::get<CBookmark>(BookmarkItem2);
 
 		return Bookmark1.GetVisitCount() - Bookmark2.GetVisitCount();
 	}
@@ -609,7 +609,7 @@ int CALLBACK SortByAdded(const NBookmarkHelper::variantBookmark_t BookmarkItem1,
 	else
 	{
 		const CBookmark &Bookmark1 = boost::get<CBookmark>(BookmarkItem1);
-		const CBookmark &Bookmark2 = boost::get<CBookmark>(BookmarkItem1);
+		const CBookmark &Bookmark2 = boost::get<CBookmark>(BookmarkItem2);
 
 		FILETIME ft1 = Bookmark1.GetDateCreated();
 		FILETIME ft2 = Bookmark2.GetDateCreated();
@@ -635,7 +635,7 @@ int CALLBACK SortByLastModified(const NBookmarkHelper::variantBookmark_t Bookmar
 	else
 	{
 		const CBookmark &Bookmark1 = boost::get<CBookmark>(BookmarkItem1);
-		const CBookmark &Bookmark2 = boost::get<CBookmark>(BookmarkItem1);
+		const CBookmark &Bookmark2 = boost::get<CBookmark>(BookmarkItem2);
 
 		FILETIME ft1 = Bookmark1.GetDateModified();
 		FILETIME ft2 = Bookmark2.GetDateModified();

--- a/Explorer++/Explorer++/Explorer++.cpp
+++ b/Explorer++/Explorer++/Explorer++.cpp
@@ -77,6 +77,7 @@ m_hContainer(hwnd)
 	m_hActiveListView				= NULL;
 	m_hTabFont						= NULL;
 	m_hNextClipboardViewer			= NULL;
+	m_hLanguageModule				= NULL;
 	m_ListViewMButtonItem			= -1;
 	m_zDeltaTotal					= 0;
 	m_iPreviousTabSelectionId		= -1;


### PR DESCRIPTION
Hello!
I'm a member of the Pinguem.ru competition on finding errors in open source projects.
I found an issue with Explorer++ bookmarks where you're not able to sort already bookmarked entities. To reproduce the bug follow these steps:

- Bookmark random directories in your file system either via `Ctrl+D` shortcut either by executing `Bookmarks -> Bookmark This Tab...` command.
- Goto `Manage Bookmarks` dialog window either via `Ctrl+B` either by executing `Bookmarks -> Manage Bookmarks...` command.
- Try to sort entities you've just added through `Views -> Sort -> Sort by [sort-criteria]` commands. It does nothing — entities are shown in order as they were added.

Solution is simple — there was a typo which was succesfully found by PVS-Studio analyzer:

- [V537](https://www.viva64.com/en/w/v537/) Consider reviewing the correctness of 'BookmarkItem1' item's usage. bookmarkhelper.cpp 535
- [V537](https://www.viva64.com/en/w/v537/) Consider reviewing the correctness of 'BookmarkItem1' item's usage. bookmarkhelper.cpp 552
- [V537](https://www.viva64.com/en/w/v537/) Consider reviewing the correctness of 'BookmarkItem1' item's usage. bookmarkhelper.cpp 569
- [V537](https://www.viva64.com/en/w/v537/) Consider reviewing the correctness of 'BookmarkItem1' item's usage. bookmarkhelper.cpp 589
- [V537](https://www.viva64.com/en/w/v537/) Consider reviewing the correctness of 'BookmarkItem1' item's usage. bookmarkhelper.cpp 612
- [V537](https://www.viva64.com/en/w/v537/) Consider reviewing the correctness of 'BookmarkItem1' item's usage. bookmarkhelper.cpp 638