### PR TITLE
Skip rename to the same filename

### DIFF
--- a/Explorer++/Explorer++/ListViewHandler.cpp
+++ b/Explorer++/Explorer++/ListViewHandler.cpp
@@ -830,6 +830,9 @@ BOOL Explorerplusplus::OnListViewEndLabelEdit(LPARAM lParam)
 		}
 	}
 
+	if (lstrcmp(OldFileName, NewFileName) == 0)
+		return FALSE;
+
 	CFileActionHandler::RenamedItem_t RenamedItem;
 	RenamedItem.strOldFilename = OldFileName;
 	RenamedItem.strNewFilename = NewFileName;


### PR DESCRIPTION
Add check to skip trying to rename a file to the same filename.
This fix prevents error message box in the case user exit from the label edition by clicking outside the edit field with no modifications. For example after just copy a filename.
