### PR TITLE
Preserve maximized window state on Win+E

### DIFF
--- a/Scripts/explorer++_win+e_binding.ahk
+++ b/Scripts/explorer++_win+e_binding.ahk
@@ -1,4 +1,4 @@
-﻿; This script runs Explorer++ on Win+E.
+; This script runs Explorer++ on Win+E.
 ; The Explorer++ executable must be in the same directory as this script file.
 
 #NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
@@ -6,10 +6,22 @@
 SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
 SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 
+; preserve maximized window state
+PreserveMaximizedState := false 
+
 #e::
-try {
-    Run %A_ScriptDir%\Explorer++.exe
-} catch e {
-    MsgBox Couldn't run Explorer++.`nPlease make sure it's in the same directory as this script (%A_ScriptDir%).
-}
+
+if PreserveMaximizedState AND WinExist("ahk_exe explorer++.exe")
+  WinActivate
+else
+  Run()
 return
+
+Run()
+{
+  try {
+      Run %A_ScriptDir%\Explorer++.exe
+  } catch e {
+      MsgBox Couldn't run Explorer++.`nPlease make sure it's in the same directory as this script (%A_ScriptDir%).
+  }
+}


### PR DESCRIPTION
Introduced a variable in ahk script. If user sets it to true, then Win+E hotkey will no longer restore (unmaximize) an already existing maximized explorer++ window.