### PR TITLE
Admin command prompt at current directory

### DIFF
--- a/Explorer++/Explorer++/MainWndSwitch.cpp
+++ b/Explorer++/Explorer++/MainWndSwitch.cpp
@@ -348,11 +348,11 @@ LRESULT Explorerplusplus::HandleMenuOrAccelerator(HWND hwnd, WPARAM wParam)
 
 	case ToolbarButton::OpenCommandPrompt:
 	case IDM_FILE_OPENCOMMANDPROMPT:
-		StartCommandPrompt(m_CurrentDirectory.c_str(), false);
+		StartCommandPrompt(m_CurrentDirectory, false);
 		break;
 
 	case IDM_FILE_OPENCOMMANDPROMPTADMINISTRATOR:
-		StartCommandPrompt(m_CurrentDirectory.c_str(), true);
+		StartCommandPrompt(m_CurrentDirectory, true);
 		break;
 
 	case IDM_FILE_COPYFOLDERPATH:

--- a/Explorer++/Helper/Helper.cpp
+++ b/Explorer++/Helper/Helper.cpp
@@ -126,7 +126,7 @@ BOOL CreateFriendlySystemTimeString(const SYSTEMTIME *localSystemTime,
 	return FALSE;
 }
 
-HINSTANCE StartCommandPrompt(const TCHAR *Directory, bool Elevated)
+HINSTANCE StartCommandPrompt(const std::wstring &Directory, bool Elevated)
 {
 	HINSTANCE hNewInstance = NULL;
 
@@ -141,17 +141,19 @@ HINSTANCE StartCommandPrompt(const TCHAR *Directory, bool Elevated)
 		if(szRet != NULL)
 		{
 			TCHAR Operation[32];
+			std::wstring Parameters(_T(""));
 
 			if(Elevated)
 			{
 				StringCchCopy(Operation, SIZEOF_ARRAY(Operation), _T("runas"));
+				Parameters = _T("/K cd /d ") + Directory;
 			}
 			else
 			{
 				StringCchCopy(Operation, SIZEOF_ARRAY(Operation), _T("open"));
 			}
 
-			hNewInstance = ShellExecute(NULL, Operation, CommandPath, NULL, Directory,
+			hNewInstance = ShellExecute(NULL, Operation, CommandPath, Parameters.c_str(), Directory.c_str(),
 				SW_SHOWNORMAL);
 		}
 	}

--- a/Explorer++/Helper/Helper.h
+++ b/Explorer++/Helper/Helper.h
@@ -49,7 +49,7 @@ BOOL			FormatUserName(PSID sid, TCHAR *userName, size_t cchMax);
 BOOL			GetFileNameFromUser(HWND hwnd,TCHAR *FullFileName,UINT cchMax,const TCHAR *InitialDirectory);
 
 /* General helper functions. */
-HINSTANCE		StartCommandPrompt(const TCHAR *Directory, bool Elevated);
+HINSTANCE		StartCommandPrompt(const std::wstring &Directory, bool Elevated);
 void			GetCPUBrandString(char *pszCPUBrand, UINT cchBuf);
 void			SetFORMATETC(FORMATETC *pftc, CLIPFORMAT cfFormat, DVTARGETDEVICE *ptd, DWORD dwAspect, LONG lindex, DWORD tymed);
 BOOL			CopyTextToClipboard(const std::wstring &str);


### PR DESCRIPTION
At present, the Admin command prompt (from file menu) will show the prompt at the default path (C:\Windows\System32).
Fixed this behavior to show the admin command prompt with current directory (like what non-admin command prompt show).