### PR TITLE
Invoke application from Application Toolbar as Administrator, if Control key is pressed during Drag & Drop (or click).

### DIFF
--- a/Explorer++/Explorer++/ApplicationToolbar.cpp
+++ b/Explorer++/Explorer++/ApplicationToolbar.cpp
@@ -319,8 +319,11 @@ void ApplicationToolbar::OpenItem(int iItem, std::wstring *parameters)
 				combinedParameters.append(_T(" "));
 				combinedParameters.append(*parameters);
 			}
+			
+			// Run it as Admin if Control key is pressed.
+			bool RunAsAdmin = (GetKeyState(VK_CONTROL) & (1 << 7) ? true : false);
 
-			m_pexpp->OpenFileItem(pidl.get(), combinedParameters.c_str());
+			m_pexpp->OpenFileItem(pidl.get(), combinedParameters.c_str(), RunAsAdmin);
 		}
 	}
 }

--- a/Explorer++/Explorer++/CoreInterface.h
+++ b/Explorer++/Explorer++/CoreInterface.h
@@ -53,7 +53,7 @@ __interface IExplorerplusplus
 
 	StatusBar		*GetStatusBar();
 
-	void			OpenFileItem(PCIDLIST_ABSOLUTE pidlItem, const TCHAR *szParameters);
+	void			OpenFileItem(PCIDLIST_ABSOLUTE pidlItem, const TCHAR *szParameters, bool RunAsAdmin);
 
 	HMENU			BuildViewsMenu();
 

--- a/Explorer++/Explorer++/Explorer++.h
+++ b/Explorer++/Explorer++/Explorer++.h
@@ -424,7 +424,7 @@ private:
 	void OpenItem(const TCHAR *szItem, BOOL bOpenInNewTab, BOOL bOpenInNewWindow) override;
 	void OpenItem(PCIDLIST_ABSOLUTE pidlItem, BOOL bOpenInNewTab, BOOL bOpenInNewWindow) override;
 	void OpenFolderItem(PCIDLIST_ABSOLUTE pidlItem, BOOL bOpenInNewTab, BOOL bOpenInNewWindow);
-	void OpenFileItem(PCIDLIST_ABSOLUTE pidlItem, const TCHAR *szParameters) override;
+	void OpenFileItem(PCIDLIST_ABSOLUTE pidlItem, const TCHAR *szParameters, bool RunAsAdmin) override;
 	HRESULT OnListViewCopy(BOOL bCopy);
 
 	/* File context menu. */

--- a/Explorer++/Explorer++/MsgHandler.cpp
+++ b/Explorer++/Explorer++/MsgHandler.cpp
@@ -295,15 +295,17 @@ void Explorerplusplus::OpenFolderItem(PCIDLIST_ABSOLUTE pidlItem, BOOL bOpenInNe
 		m_navigation->BrowseFolderInCurrentTab(pidlItem);
 }
 
-void Explorerplusplus::OpenFileItem(PCIDLIST_ABSOLUTE pidlItem,const TCHAR *szParameters)
+void Explorerplusplus::OpenFileItem(PCIDLIST_ABSOLUTE pidlItem, const TCHAR *szParameters, bool RunAsAdmin)
 {
 	unique_pidl_absolute pidlParent(ILCloneFull(pidlItem));
 	ILRemoveLastID(pidlParent.get());
 
 	TCHAR szItemDirectory[MAX_PATH];
 	GetDisplayName(pidlParent.get(),szItemDirectory,SIZEOF_ARRAY(szItemDirectory),SHGDN_FORPARSING);
+	
+	const TCHAR *szVerb = (RunAsAdmin ? _T("RunAs") : EMPTY_STRING);
 
-	ExecuteFileAction(m_hContainer,EMPTY_STRING,szParameters,szItemDirectory,pidlItem);
+	ExecuteFileAction(m_hContainer,szVerb,szParameters,szItemDirectory,pidlItem);
 }
 
 BOOL Explorerplusplus::OnSize(int MainWindowWidth,int MainWindowHeight)

--- a/Explorer++/Explorer++/MsgHandler.cpp
+++ b/Explorer++/Explorer++/MsgHandler.cpp
@@ -194,7 +194,7 @@ void Explorerplusplus::OpenItem(PCIDLIST_ABSOLUTE pidlItem, BOOL bOpenInNewTab, 
 			}
 			else
 			{
-				OpenFileItem(pidlItem,EMPTY_STRING);
+				OpenFileItem(pidlItem,EMPTY_STRING,false);
 			}
 		}
 		else if(((uAttributes & SFGAO_FOLDER) && !bControlPanelParent))
@@ -255,7 +255,7 @@ void Explorerplusplus::OpenItem(PCIDLIST_ABSOLUTE pidlItem, BOOL bOpenInNewTab, 
 				Also, even if the shortcut points to a dead
 				folder, it should still attempted to be
 				opened. */
-				OpenFileItem(pidlItem,EMPTY_STRING);
+				OpenFileItem(pidlItem,EMPTY_STRING,false);
 			}
 		}
 		else if(bControlPanelParent && (uAttributes & SFGAO_FOLDER))
@@ -280,7 +280,7 @@ void Explorerplusplus::OpenItem(PCIDLIST_ABSOLUTE pidlItem, BOOL bOpenInNewTab, 
 		else
 		{
 			/* File item. */
-			OpenFileItem(pidlItem,EMPTY_STRING);
+			OpenFileItem(pidlItem,EMPTY_STRING,false);
 		}
 	}
 }


### PR DESCRIPTION
Sometimes, it is desirable to invoke an application from the Application Toolbar as Administrator.  For example, you want to modify a configuration file residing in your software installation folder inside C:\ProgramFiles(x86).  You need to do this with an editor started in Admin mode.
Invoke the application as Admin if Control key is pressed during drag & drop or click.