### PR TITLE
implemented #217 -- use column layout of current tab in new tab when ctrl+t is exec'd on a directory

### DIFF
--- a/Explorer++/Explorer++/SelectColumnsDialog.cpp
+++ b/Explorer++/Explorer++/SelectColumnsDialog.cpp
@@ -48,16 +48,7 @@ INT_PTR SelectColumnsDialog::OnInitDialog()
 
 	for(const auto &column : currentColumns)
 	{
-		std::wstring text;
-		
-		try
-		{
-			text = ResourceHelper::LoadString(GetInstance(),ShellBrowser::LookupColumnNameStringIndex(column.id));
-		}
-		catch (const std::runtime_error& ex)
-		{
-			ex.what();
-		}
+		std::wstring text = ResourceHelper::LoadString(GetInstance(),ShellBrowser::LookupColumnNameStringIndex(column.id));
 
 		LVITEM lvItem;
 		lvItem.mask		= LVIF_TEXT|LVIF_PARAM;

--- a/Explorer++/Explorer++/SelectColumnsDialog.cpp
+++ b/Explorer++/Explorer++/SelectColumnsDialog.cpp
@@ -48,7 +48,16 @@ INT_PTR SelectColumnsDialog::OnInitDialog()
 
 	for(const auto &column : currentColumns)
 	{
-		std::wstring text = ResourceHelper::LoadString(GetInstance(),ShellBrowser::LookupColumnNameStringIndex(column.id));
+		std::wstring text;
+		
+		try
+		{
+			text = ResourceHelper::LoadString(GetInstance(),ShellBrowser::LookupColumnNameStringIndex(column.id));
+		}
+		catch (const std::runtime_error& ex)
+		{
+			ex.what();
+		}
 
 		LVITEM lvItem;
 		lvItem.mask		= LVIF_TEXT|LVIF_PARAM;

--- a/Explorer++/Explorer++/SetDefaultColumnsDialog.cpp
+++ b/Explorer++/Explorer++/SetDefaultColumnsDialog.cpp
@@ -251,7 +251,7 @@ void SetDefaultColumnsDialog::SaveCurrentColumnState(FolderType folderType)
 {
 	HWND hListView = GetDlgItem(m_hDlg,IDC_DEFAULTCOLUMNS_LISTVIEW);
 
-	auto currentColumns = GetCurrentColumnList(folderType);
+	auto & currentColumns = GetCurrentColumnList(folderType);
 	std::vector<Column_t> tempColumns;
 
 	for(int i = 0;i < ListView_GetItemCount(hListView);i++)
@@ -275,7 +275,7 @@ void SetDefaultColumnsDialog::SaveCurrentColumnState(FolderType folderType)
 		tempColumns.push_back(column);
 	}
 
-	currentColumns = tempColumns;
+	currentColumns.swap(tempColumns);
 }
 
 void SetDefaultColumnsDialog::SetupFolderColumns(FolderType folderType)

--- a/Explorer++/Explorer++/TabHandler.cpp
+++ b/Explorer++/Explorer++/TabHandler.cpp
@@ -83,7 +83,6 @@ void Explorerplusplus::OnNavigationCompleted(const Tab &tab)
 HRESULT Explorerplusplus::OnNewTab()
 {
 	const Tab &selectedTab = m_tabContainer->GetSelectedTab();
-	FolderColumns cols = selectedTab.GetShellBrowser()->ExportAllColumns();
 	int selectionIndex = ListView_GetNextItem(
 		selectedTab.GetShellBrowser()->GetListView(), -1, LVNI_FOCUSED | LVNI_SELECTED);
 
@@ -96,6 +95,7 @@ HRESULT Explorerplusplus::OnNewTab()
 		if (WI_IsFlagSet(fileFindData.dwFileAttributes, FILE_ATTRIBUTE_DIRECTORY))
 		{
 			auto pidl = selectedTab.GetShellBrowser()->GetItemCompleteIdl(selectionIndex);
+			FolderColumns cols = selectedTab.GetShellBrowser()->ExportAllColumns();
 			return m_tabContainer->CreateNewTab(pidl.get(), TabSettings(_selected = true), nullptr, cols);
 		}
 	}

--- a/Explorer++/Explorer++/TabHandler.cpp
+++ b/Explorer++/Explorer++/TabHandler.cpp
@@ -83,6 +83,7 @@ void Explorerplusplus::OnNavigationCompleted(const Tab &tab)
 HRESULT Explorerplusplus::OnNewTab()
 {
 	const Tab &selectedTab = m_tabContainer->GetSelectedTab();
+	FolderColumns cols = selectedTab.GetShellBrowser()->ExportAllColumns();
 	int selectionIndex = ListView_GetNextItem(
 		selectedTab.GetShellBrowser()->GetListView(), -1, LVNI_FOCUSED | LVNI_SELECTED);
 
@@ -95,7 +96,7 @@ HRESULT Explorerplusplus::OnNewTab()
 		if (WI_IsFlagSet(fileFindData.dwFileAttributes, FILE_ATTRIBUTE_DIRECTORY))
 		{
 			auto pidl = selectedTab.GetShellBrowser()->GetItemCompleteIdl(selectionIndex);
-			return m_tabContainer->CreateNewTab(pidl.get(), TabSettings(_selected = true));
+			return m_tabContainer->CreateNewTab(pidl.get(), TabSettings(_selected = true), nullptr, cols);
 		}
 	}
 


### PR DESCRIPTION
For consideration, implementation of feature request #217.
Exec of ctrl+t on a directory opens a new tab using the same columns and widths as the tab the command was exec'd in.