### PR TITLE
implemented feature request #212 -- go back command sets focus to previously selected folder

### DIFF
--- a/Explorer++/Explorer++/MainMenuHandler.cpp
+++ b/Explorer++/Explorer++/MainMenuHandler.cpp
@@ -285,7 +285,12 @@ void Explorerplusplus::OnResolveLink()
 HRESULT Explorerplusplus::OnGoBack()
 {
 	Tab &selectedTab = m_tabContainer->GetSelectedTab();
-	return selectedTab.GetShellBrowser()->GetNavigationController()->GoBack();
+	auto curEntry = selectedTab.GetShellBrowser()->GetNavigationController()->GetEntry(0);
+	auto res = selectedTab.GetShellBrowser()->GetNavigationController()->GoBack();
+	auto prevName = curEntry->GetDisplayName();
+	if (!prevName.empty())
+		selectedTab.GetShellBrowser()->SelectFiles(prevName.c_str());
+	return res;
 }
 
 HRESULT Explorerplusplus::OnGoForward()


### PR DESCRIPTION
for consideration, implementation of feature request #212 
after entry into a directory, alt+left/navigate back selects that directory item in the parent directory view