### PR TITLE
implemented #217 -- use column layout of current tab in new tab when ctrl+t is exec'd on a directory

### DIFF
--- a/Explorer++/Explorer++/TabHandler.cpp
+++ b/Explorer++/Explorer++/TabHandler.cpp
@@ -96,7 +96,8 @@ HRESULT Explorerplusplus::OnNewTab()
 		{
 			auto pidl = selectedTab.GetShellBrowser()->GetItemCompleteIdl(selectionIndex);
 			FolderColumns cols = selectedTab.GetShellBrowser()->ExportAllColumns();
-			return m_tabContainer->CreateNewTab(pidl.get(), TabSettings(_selected = true), nullptr, cols);
+			return m_tabContainer->CreateNewTab(
+				pidl.get(), TabSettings(_selected = true), nullptr, cols);
 		}
 	}
 

--- a/Explorer++/Explorer++/TabHandler.cpp
+++ b/Explorer++/Explorer++/TabHandler.cpp
@@ -95,7 +95,8 @@ HRESULT Explorerplusplus::OnNewTab()
 		if (WI_IsFlagSet(fileFindData.dwFileAttributes, FILE_ATTRIBUTE_DIRECTORY))
 		{
 			auto pidl = selectedTab.GetShellBrowser()->GetItemCompleteIdl(selectionIndex);
-			return m_tabContainer->CreateNewTab(pidl.get(), TabSettings(_selected = true));
+			FolderColumns cols = selectedTab.GetShellBrowser()->ExportAllColumns();
+			return m_tabContainer->CreateNewTab(pidl.get(), TabSettings(_selected = true), nullptr, cols);
 		}
 	}
 


### PR DESCRIPTION
for consideration, implementation of feature request #217.
use column layout/widths of current tab in the new tab when ctrl+t is exec'd on a directory.