### PR TITLE
Fix persistent column state by changing type of currentColumns to auto…

### DIFF
--- a/Explorer++/Explorer++/SetDefaultColumnsDialog.cpp
+++ b/Explorer++/Explorer++/SetDefaultColumnsDialog.cpp
@@ -270,7 +270,7 @@ void SetDefaultColumnsDialog::SaveCurrentColumnState(FolderType folderType)
 {
 	HWND hListView = GetDlgItem(m_hDlg, IDC_DEFAULTCOLUMNS_LISTVIEW);
 
-	auto currentColumns = GetCurrentColumnList(folderType);
+	auto &currentColumns = GetCurrentColumnList(folderType);
 	std::vector<Column_t> tempColumns;
 
 	for (int i = 0; i < ListView_GetItemCount(hListView); i++)


### PR DESCRIPTION
… & from auto (auto strips the 'reference' qualifier from the inferred type) in SetDefaultColumnsDialog::SaveCurrentColumnState.