### PR TITLE
Disable advertised shortcuts in the installers

### DIFF
--- a/Explorer++/Installer/Explorer++.wxs
+++ b/Explorer++/Installer/Explorer++.wxs
@@ -53,8 +53,8 @@
 		<ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
 			<Component Id="MainExecutable" Guid="64A067D6-381D-4C81-A24D-F0FC735B5E19">
 					<File Id="ExplorerppEXE" Name="Explorer++.exe" DiskId="1" Source="$(var.Explorer++.TargetPath)" KeyPath="yes" Checksum="yes">
-						<Shortcut Id="ApplicationStartMenuShortcut" Directory="ApplicationProgramsFolder" Name="Explorer++" WorkingDirectory="INSTALLDIR" Icon="Explorerpp.ico" IconIndex="0" Advertise="yes" />
-						<Shortcut Id="ApplicationDesktopShortcut" Directory="DesktopFolder" Name="Explorer++" WorkingDirectory="INSTALLDIR" Icon="Explorerpp.ico" IconIndex="0" Advertise="yes" />
+						<Shortcut Id="ApplicationStartMenuShortcut" Directory="ApplicationProgramsFolder" Name="Explorer++" WorkingDirectory="INSTALLDIR" Icon="Explorerpp.ico" IconIndex="0" />
+						<Shortcut Id="ApplicationDesktopShortcut" Directory="DesktopFolder" Name="Explorer++" WorkingDirectory="INSTALLDIR" Icon="Explorerpp.ico" IconIndex="0" />
 					</File>
 			</Component>
 			<Component Id="History" Guid="0CB49788-9CBD-403C-863C-A02060659179">


### PR DESCRIPTION
Hi, you should disable advertised shortcuts in the installers.
Because your app after installation doesn't have an icon and you can't run it as admin.
![Windows 10 Start menu](https://user-images.githubusercontent.com/23485114/96943735-d47d9b80-14e5-11eb-809e-0b2daea01ee6.png)