### PR TITLE
Add margin to the icons in the "List" view

### DIFF
--- a/Explorer++/Explorer++/ShellBrowser/ShellBrowserImpl.h
+++ b/Explorer++/Explorer++/ShellBrowser/ShellBrowserImpl.h
@@ -404,6 +404,7 @@ private:
 
 	static HWND CreateListView(HWND parent);
 	void InitializeListView();
+	HIMAGELIST GetIconsList(int margin);
 	int GenerateUniqueItemId();
 	void MarkItemAsCut(int item, bool cut);
 	void VerifySortMode();


### PR DESCRIPTION
Now fixed to just 1 pixel to avoid icons touching each other,
but it can be made configurable in the future.