### PR TITLE
Add support for EXPLORERPP_CONFIG env var

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -12,11 +12,15 @@
 
 [vcpkg](https://vcpkg.io/) is used to manage dependencies. Before you can build Explorer++, you'll first need to initialize vcpkg:
 
-`git clone --recurse-submodules https://github.com/derceg/explorerplusplus.git`
+- Clone this repo with submodules enabled:
+```
+git clone --recurse-submodules https://github.com/derceg/explorerplusplus.git
+cd explorerplusplus
+```
+- Run the vcpkg bootstrapper:
+    - cmd/PowerShell: `.\Explorer++\ThirdParty\vcpkg\bootstrap-vcpkg.bat`
+    - git bash/posix shell: `./Explorer++/ThirdParty/vcpkg/bootstrap-vcpkg.sh`
 
-`cd explorerplusplus`
-
-`.\Explorer++\ThirdParty\vcpkg\bootstrap-vcpkg.bat`
 
 The relevant packages should then be automatically installed during the first build.
 

--- a/Documentation/User/History.txt
+++ b/Documentation/User/History.txt
@@ -108,6 +108,8 @@ New features:
   (Brazil) translations.
 - The layout will now be switched to RTL when using the Arabic or
   Hebrew translations.
+- Config file location can be specified with the EXPLORERPP_CONFIG
+  environment variable.
 
 Bug fixes:
 - Fixed a crash that could occur on startup when the "Open new

--- a/Documentation/User/Sphinx/menus/tools/options/general.rst
+++ b/Documentation/User/Sphinx/menus/tools/options/general.rst
@@ -72,17 +72,23 @@ Run in portable mode
 ~~~~~~~~~~~~~~~~~~~~
 
 +-----------------+------------------------------------+
-| System Default: | No (if no config.xml file present) |
+| System Default: | No (if no config file present)     |
 +-----------------+------------------------------------+
 
 .. _install_folder:
 
 Enabling this option (ie. checking the box) tells **Explorer++** to save
-and fetch all its settings in an XML (**config.xml**) file, located in
-the installation folder, usually ...\\Program Files\\Explorer++ v1.2
-(your version might be different). An XML file is a text file,
-structured hierarchically to enable **Explorer++** to re-construct its
-settings, etc. at program startup.
+and fetch all its settings to an XML file (a text file, structured
+hierarchically to enable **Explorer++** to re-construct its
+settings, etc. at program startup).
+
+By default, the XML file is named .config.xml and is located in the
+installation folder, usually ...\\Program Files\\Explorer++ v1.2
+(your version might be different). You can change where the config file
+is found by setting the environment variable ``EXPLORERPP_CONFIG`` to
+the full path to the file where you would like to store yours.  If the
+variable points to an invalid location, the Windows registry will be
+used as a fallback.
 
 .. note::
 

--- a/Explorer++/Explorer++/Storage.cpp
+++ b/Explorer++/Explorer++/Storage.cpp
@@ -10,8 +10,31 @@
 namespace Storage
 {
 
+std::optional<std::wstring> GetEnvironmentVariableWrapper(const std::wstring &name)
+{
+	auto length = GetEnvironmentVariable(name.c_str(), nullptr, 0);
+	if (length == 0)
+	{
+		return std::nullopt;
+	}
+
+	std::wstring value;
+	value.resize(length);
+	length = GetEnvironmentVariable(name.c_str(), value.data(), length);
+	if (length == 0)
+	{
+		return std::nullopt;
+	}
+	return value;
+}
+
 std::wstring GetConfigFilePath()
 {
+	auto configPath = GetEnvironmentVariableWrapper(CONFIG_FILE_ENV_VAR_NAME);
+	if (configPath) {
+		return configPath->c_str();
+	}
+
 	wchar_t currentProcessPath[MAX_PATH];
 	GetProcessImageName(GetCurrentProcessId(), currentProcessPath, std::size(currentProcessPath));
 

--- a/Explorer++/Explorer++/Storage.h
+++ b/Explorer++/Explorer++/Storage.h
@@ -23,6 +23,7 @@ inline const wchar_t REGISTRY_SETTINGS_KEY_NAME[] = L"Settings";
 inline const wchar_t CONFIG_FILE_FILENAME[] = L"config.xml";
 inline const wchar_t CONFIG_FILE_ROOT_NODE_NAME[] = L"ExplorerPlusPlus";
 inline const wchar_t CONFIG_FILE_SETTINGS_NODE_NAME[] = L"Settings";
+inline const wchar_t CONFIG_FILE_ENV_VAR_NAME[] = L"EXPLORERPP_CONFIG";
 
 std::wstring GetConfigFilePath();
 


### PR DESCRIPTION
If set, this environment variable controls specifies the full path to where the xml config file will be saved/loaded.  Useful for storing config in a place that's sync'd, as well as naming it something less generic than "config.xml".  e.g.
```
EXPLORERPP_CONFIG=%USERPROFILE%\dotfiles\explorer++.xml
```
