### PR TITLE
Move frequent locations to separate XML file

### DIFF
--- a/Explorer++/Explorer++/App.cpp
+++ b/Explorer++/Explorer++/App.cpp
@@ -173,7 +173,27 @@ void App::LoadSettings(std::vector<WindowStorageData> &windows)
 	appStorage->LoadApplications(&m_applicationModel);
 	appStorage->LoadDialogStates();
 	appStorage->LoadDefaultColumns(m_config.globalFolderSettings.folderColumns);
-	appStorage->LoadFrequentLocations(&m_frequentLocationsModel);
+
+	if (m_savePreferencesToXmlFile)
+	{
+		auto frequentLocationsStorage = XmlAppStorageFactory::MaybeCreate(
+			Storage::GetFrequentLocationsFilePath(), Storage::OperationType::Load);
+
+		if (frequentLocationsStorage)
+		{
+			frequentLocationsStorage->LoadFrequentLocations(&m_frequentLocationsModel);
+		}
+		else
+		{
+			// Older versions stored frequent locations in config.xml. Fall back to that data so
+			// that it can be migrated to the separate file the next time settings are saved.
+			appStorage->LoadFrequentLocations(&m_frequentLocationsModel);
+		}
+	}
+	else
+	{
+		appStorage->LoadFrequentLocations(&m_frequentLocationsModel);
+	}
 
 	ValidateColumns(m_config.globalFolderSettings.folderColumns);
 }
@@ -219,7 +239,22 @@ void App::SaveSettings()
 	appStorage->SaveApplications(&m_applicationModel);
 	appStorage->SaveDialogStates();
 	appStorage->SaveDefaultColumns(m_config.globalFolderSettings.folderColumns);
-	appStorage->SaveFrequentLocations(&m_frequentLocationsModel);
+
+	if (m_savePreferencesToXmlFile)
+	{
+		auto frequentLocationsStorage = XmlAppStorageFactory::MaybeCreate(
+			Storage::GetFrequentLocationsFilePath(), Storage::OperationType::Save);
+
+		if (frequentLocationsStorage)
+		{
+			frequentLocationsStorage->SaveFrequentLocations(&m_frequentLocationsModel);
+			frequentLocationsStorage->Commit();
+		}
+	}
+	else
+	{
+		appStorage->SaveFrequentLocations(&m_frequentLocationsModel);
+	}
 
 	appStorage->Commit();
 }

--- a/Explorer++/Explorer++/Storage.cpp
+++ b/Explorer++/Explorer++/Storage.cpp
@@ -28,4 +28,12 @@ std::wstring GetConfigFilePath()
 	return configFilePath.c_str();
 }
 
+std::wstring GetFrequentLocationsFilePath()
+{
+	std::filesystem::path frequentLocationsFilePath(GetConfigFilePath());
+	frequentLocationsFilePath.replace_filename(FREQUENT_LOCATIONS_FILE_FILENAME);
+
+	return frequentLocationsFilePath.c_str();
+}
+
 }

--- a/Explorer++/Explorer++/Storage.h
+++ b/Explorer++/Explorer++/Storage.h
@@ -25,7 +25,9 @@ inline const wchar_t CONFIG_FILE_FILENAME[] = L"config.xml";
 inline const wchar_t CONFIG_FILE_ROOT_NODE_NAME[] = L"ExplorerPlusPlus";
 inline const wchar_t CONFIG_FILE_SETTINGS_NODE_NAME[] = L"Settings";
 inline const wchar_t CONFIG_FILE_ENV_VAR_NAME[] = L"EXPLORERPP_CONFIG";
+inline const wchar_t FREQUENT_LOCATIONS_FILE_FILENAME[] = L"frequent_locations.xml";
 
 std::wstring GetConfigFilePath();
+std::wstring GetFrequentLocationsFilePath();
 
 }

--- a/Explorer++/TestExplorer++/StorageTest.cpp
+++ b/Explorer++/TestExplorer++/StorageTest.cpp
@@ -25,3 +25,21 @@ TEST(StorageTest, ConfigEnvVar)
 	path = Storage::GetConfigFilePath();
 	ASSERT_TRUE(path.ends_with(L"config.xml"));
 }
+
+TEST(StorageTest, FrequentLocationsFilePath)
+{
+	auto set = SetEnvironmentVariable(Storage::CONFIG_FILE_ENV_VAR_NAME, NULL);
+	ASSERT_TRUE(set);
+	auto path = Storage::GetFrequentLocationsFilePath();
+	ASSERT_TRUE(path.ends_with(L"frequent_locations.xml"));
+
+	set = SetEnvironmentVariable(L"FOO", L"BAR");
+	ASSERT_TRUE(set);
+	set = SetEnvironmentVariable(Storage::CONFIG_FILE_ENV_VAR_NAME, L"%FOO%\\explorerpp.xml");
+	ASSERT_TRUE(set);
+	path = Storage::GetFrequentLocationsFilePath();
+	ASSERT_EQ(path, L"BAR\\frequent_locations.xml");
+
+	set = SetEnvironmentVariable(Storage::CONFIG_FILE_ENV_VAR_NAME, NULL);
+	ASSERT_TRUE(set);
+}


### PR DESCRIPTION
## Summary

- store frequent locations in a separate `frequent_locations.xml` file when XML preferences are enabled
- load legacy frequent-location data from `config.xml` when the new file does not exist, allowing it to migrate on the next save
- derive the new file path from the configured `config.xml` location, including when `EXPLORERPP_CONFIG` is used
- keep registry-based preference storage unchanged

## Motivation

Frequent locations are machine-specific usage data rather than portable application preferences. Keeping them in `config.xml` makes that file less suitable for reuse on another PC.

## User impact

Users can copy `config.xml` between machines without also copying their frequent-location history. Existing XML configurations migrate automatically without losing their current frequent locations.

## Validation

- built `Explorer++` in `Release|x64`
- built `TestExplorer++` in `Release|x64`
- passed all 12 `FrequentLocations*` tests
- passed `StorageTest.ConfigEnvVar` and `StorageTest.FrequentLocationsFilePath`
