### PR TITLE
Restore custom fonts after theme changes

### DIFF
--- a/Explorer++/Explorer++/MainFontSetter.cpp
+++ b/Explorer++/Explorer++/MainFontSetter.cpp
@@ -15,8 +15,7 @@ MainFontSetter::MainFontSetter(HWND hwnd, const Config *config,
 	m_config(config),
 	m_defaultFontAt96Dpi(defaultFontAt96Dpi)
 {
-	SubclassWindowForDpiChanges();
-	MaybeSubclassSpecificWindowClasses();
+	InstallWindowSubclass();
 	UpdateFont();
 
 	m_connections.push_back(
@@ -25,7 +24,7 @@ MainFontSetter::MainFontSetter(HWND hwnd, const Config *config,
 
 MainFontSetter::~MainFontSetter() = default;
 
-void MainFontSetter::SubclassWindowForDpiChanges()
+void MainFontSetter::InstallWindowSubclass()
 {
 	m_windowSubclasses.push_back(
 		std::make_unique<WindowSubclass>(m_hwnd, std::bind_front(&MainFontSetter::WndProc, this)));
@@ -38,6 +37,21 @@ LRESULT MainFontSetter::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
 	case WM_DPICHANGED_AFTERPARENT:
 		OnDpiChanged();
 		break;
+
+	case WM_THEMECHANGED:
+	{
+		auto res = DefSubclassProc(hwnd, msg, wParam, lParam);
+
+		// Some controls, including toolbars and tooltips, reset their font when the theme is
+		// changed. Restore the active custom font after the control has processed the message.
+		if (m_font)
+		{
+			SendMessage(m_hwnd, WM_SETFONT, reinterpret_cast<WPARAM>(m_font.get()), true);
+			fontUpdatedSignal.m_signal();
+		}
+
+		return res;
+	}
 	}
 
 	return DefSubclassProc(hwnd, msg, wParam, lParam);
@@ -53,49 +67,6 @@ void MainFontSetter::OnDpiChanged()
 	}
 
 	UpdateFont();
-}
-
-void MainFontSetter::MaybeSubclassSpecificWindowClasses()
-{
-	WCHAR className[256];
-	auto res = GetClassName(m_hwnd, className, static_cast<int>(std::size(className)));
-
-	if (res == 0)
-	{
-		DCHECK(false);
-		return;
-	}
-
-	if (lstrcmp(className, TOOLTIPS_CLASS) == 0)
-	{
-		m_windowSubclasses.push_back(std::make_unique<WindowSubclass>(m_hwnd,
-			std::bind_front(&MainFontSetter::TooltipWndProc, this)));
-	}
-}
-
-LRESULT MainFontSetter::TooltipWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
-{
-	switch (msg)
-	{
-	case WM_THEMECHANGED:
-	{
-		auto res = DefSubclassProc(hwnd, msg, wParam, lParam);
-
-		// The tooltip control will internally reset its font when it receives a WM_THEMECHANGED
-		// message. Therefore, if a custom font is currently active within the application, that
-		// font will need to be restored. If a custom font isn't active, the control can use the
-		// default font it sets.
-		if (m_font)
-		{
-			SendMessage(m_hwnd, WM_SETFONT, reinterpret_cast<WPARAM>(m_font.get()), true);
-		}
-
-		return res;
-	}
-	break;
-	}
-
-	return DefSubclassProc(hwnd, msg, wParam, lParam);
 }
 
 void MainFontSetter::UpdateFont()

--- a/Explorer++/Explorer++/MainFontSetter.h
+++ b/Explorer++/Explorer++/MainFontSetter.h
@@ -25,11 +25,9 @@ public:
 	SignalWrapper<MainFontSetter, void()> fontUpdatedSignal;
 
 private:
-	void SubclassWindowForDpiChanges();
+	void InstallWindowSubclass();
 	LRESULT WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 	void OnDpiChanged();
-	void MaybeSubclassSpecificWindowClasses();
-	LRESULT TooltipWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 	void UpdateFont();
 
 	HWND m_hwnd;

--- a/Explorer++/TestExplorer++/BookmarksToolbarTest.cpp
+++ b/Explorer++/TestExplorer++/BookmarksToolbarTest.cpp
@@ -179,7 +179,8 @@ TEST_F(BookmarksToolbarFontTest, UsesConfiguredFontOnStartup)
 	ASSERT_NE(toolbarFont, nullptr);
 
 	LOGFONT toolbarLogFont;
-	ASSERT_EQ(GetObject(toolbarFont, sizeof(toolbarLogFont), &toolbarLogFont), sizeof(toolbarLogFont));
+	ASSERT_EQ(GetObject(toolbarFont, sizeof(toolbarLogFont), &toolbarLogFont),
+		static_cast<int>(sizeof(toolbarLogFont)));
 
 	auto expectedFont = CreateFontFromNameAndSize(L"Segoe UI", 15,
 		m_bookmarksToolbarView->GetHWND());
@@ -187,7 +188,7 @@ TEST_F(BookmarksToolbarFontTest, UsesConfiguredFontOnStartup)
 
 	LOGFONT expectedLogFont;
 	ASSERT_EQ(GetObject(expectedFont.get(), sizeof(expectedLogFont), &expectedLogFont),
-		sizeof(expectedLogFont));
+		static_cast<int>(sizeof(expectedLogFont)));
 
 	EXPECT_EQ(toolbarLogFont, expectedLogFont);
 }

--- a/Explorer++/TestExplorer++/BookmarksToolbarTest.cpp
+++ b/Explorer++/TestExplorer++/BookmarksToolbarTest.cpp
@@ -7,12 +7,15 @@
 #include "Bookmarks/UI/Views/BookmarksToolbarView.h"
 #include "BrowserTestBase.h"
 #include "BrowserWindowFake.h"
+#include "CustomFont.h"
+#include "FontHelper.h"
 #include "IconFetcherFake.h"
 #include "PidlTestHelper.h"
 #include "ShellBrowser/ShellBrowser.h"
 #include "ShellBrowser/ShellNavigationController.h"
 #include <boost/range/combine.hpp>
 #include <gtest/gtest.h>
+#include <uxtheme.h>
 
 class BookmarksToolbarTest : public BrowserTestBase
 {
@@ -137,4 +140,54 @@ TEST_F(BookmarksToolbarTest, OpenBookmarkOnClick)
 		ASSERT_NE(currentEntry, nullptr);
 		EXPECT_EQ(currentEntry->GetPidl(), CreateSimplePidlForTest(bookmark->GetLocation()));
 	}
+}
+
+class BookmarksToolbarFontTest : public BrowserTestBase
+{
+protected:
+	BookmarksToolbarFontTest() :
+		m_browser(AddBrowser()),
+		m_bookmarksToolbarView(CreateBookmarksToolbarView(m_browser->GetHWND(), &m_config))
+	{
+		m_bookmarkTree.AddBookmarkItem(m_bookmarkTree.GetBookmarksToolbarFolder(),
+			std::make_unique<BookmarkItem>(std::nullopt, L"Bookmark", L"c:\\path"));
+
+		m_bookmarksToolbar =
+			BookmarksToolbar::Create(m_bookmarksToolbarView, m_browser, &m_acceleratorManager,
+				&m_resourceLoader, &m_iconFetcher, &m_bookmarkTree, &m_platformContext);
+	}
+
+	static BookmarksToolbarView *CreateBookmarksToolbarView(HWND parent, Config *config)
+	{
+		config->mainFont = CustomFont(L"Segoe UI", 15);
+		return BookmarksToolbarView::Create(parent, config);
+	}
+
+	IconFetcherFake m_iconFetcher;
+	BrowserWindowFake *const m_browser;
+	BookmarksToolbarView *const m_bookmarksToolbarView;
+	BookmarksToolbar *m_bookmarksToolbar = nullptr;
+};
+
+TEST_F(BookmarksToolbarFontTest, UsesConfiguredFontOnStartup)
+{
+	// The theme is applied after the main window and all its child controls have been created.
+	ASSERT_TRUE(SUCCEEDED(SetWindowTheme(m_bookmarksToolbarView->GetHWND(), L"", nullptr)));
+
+	auto toolbarFont = reinterpret_cast<HFONT>(
+		SendMessage(m_bookmarksToolbarView->GetHWND(), WM_GETFONT, 0, 0));
+	ASSERT_NE(toolbarFont, nullptr);
+
+	LOGFONT toolbarLogFont;
+	ASSERT_EQ(GetObject(toolbarFont, sizeof(toolbarLogFont), &toolbarLogFont), sizeof(toolbarLogFont));
+
+	auto expectedFont = CreateFontFromNameAndSize(L"Segoe UI", 15,
+		m_bookmarksToolbarView->GetHWND());
+	ASSERT_NE(expectedFont, nullptr);
+
+	LOGFONT expectedLogFont;
+	ASSERT_EQ(GetObject(expectedFont.get(), sizeof(expectedLogFont), &expectedLogFont),
+		sizeof(expectedLogFont));
+
+	EXPECT_EQ(toolbarLogFont, expectedLogFont);
 }


### PR DESCRIPTION
## Summary

- restore an active custom font after a control processes `WM_THEMECHANGED`
- notify font observers after restoration so toolbar button metrics and rebar sizing are refreshed
- generalize the existing tooltip-specific handling to all controls managed by `MainFontSetter`
- add a regression test covering the bookmark toolbar startup path

## Root cause

The application applies the theme after the main window and its child controls have been created. `SetWindowTheme()` causes toolbar controls to reset their font to the system default. The existing `MainFontSetter` theme-change handling only restored fonts for tooltip controls, so the bookmark toolbar used the default size after startup until the user increased or decreased the text size.

## User impact

The configured main font size is now applied consistently to the bookmark toolbar immediately after startup. Users no longer need to change the text size once per session to refresh the toolbar.

## Validation

- built `Explorer++` in `Release|x64`
- built `TestExplorer++` in `Release|x64`
- passed all 7 `BookmarksToolbar*` tests, including the new regression test
- full test suite: 781 of 782 tests passed; the remaining `FormatSizeString.Simple` failure is locale-dependent and expects a decimal point while the German locale produces a decimal comma
